### PR TITLE
Added undo-redo, removed separate collision mesh

### DIFF
--- a/Tile3D/Tile3DEditor.cs
+++ b/Tile3D/Tile3DEditor.cs
@@ -51,7 +51,7 @@ public class Tile3DEditor : Editor
     private SingleSelection hover = null;
     private MultiSelection selected = null;
     private Tile3D.Face brush = new Tile3D.Face() { Hidden = true };
-
+    
     private void OnEnable()
     {
         Undo.undoRedoPerformed += OnUndoRedo;
@@ -66,7 +66,7 @@ public class Tile3DEditor : Editor
     {
         DrawDefaultInspector();
         
-        if (GUILayout.Button("Rebuild Mesh") )
+        if (GUILayout.Button("Rebuild Mesh"))
             tiler.Rebuild();
     }
 
@@ -235,6 +235,7 @@ public class Tile3DEditor : Editor
     private bool SetBlockFace(Tile3D.Block block, Vector3 normal, Tile3D.Face brush)
     {
         Undo.RecordObject(target, "SetBlockFaces");
+
         for (int i = 0; i < Tile3D.Faces.Length; i++)
         {
             if (Vector3.Dot(normal, Tile3D.Faces[i]) > 0.8f)


### PR DESCRIPTION
Hi! I added undo-redo.

I also didn't see a good reason for the separate collision mesh, it's easier to share the same mesh used to render and it prevents the annoying green wireframe from being drawn over the mesh in the scene view. I can always undo that if you had a good reason for it.